### PR TITLE
Support dict-like parameter values in NatureInspiredSearchCV

### DIFF
--- a/sklearn_nature_inspired_algorithms/model_selection/_param_grid.py
+++ b/sklearn_nature_inspired_algorithms/model_selection/_param_grid.py
@@ -41,9 +41,20 @@ class ParamGrid:
 
         return params
 
+    def get_value_indices_from_solution_vec(self, solution_vec):
+        # the tuple of selected value indices uniquely identifies a candidate,
+        # and unlike the values themselves, it is always hashable
+        return tuple(self.__get_param_value_index(param_key, solution_vec) for param_key in self.param_grid)
+
     def __get_param_value(self, param_key, solution_vec):
+        param_value_index = self.__get_param_value_index(param_key, solution_vec)
+        return self.param_grid[param_key][param_value_index]
+
+    def __get_param_value_index(self, param_key, solution_vec):
         index = self.key_to_index_map[param_key]
         solution_value = solution_vec[index]
         param_value_count = len(self.param_grid[param_key])
-        param_value_index = min(math.floor(solution_value / (1 / param_value_count)), param_value_count - 1)
-        return self.param_grid[param_key][param_value_index]
+        # the solution value is from the [0, 1] interval, split it into equally
+        # sized buckets, one for each of the parameter values, min() handles
+        # the edge case when the solution value is exactly 1
+        return min(math.floor(solution_value / (1 / param_value_count)), param_value_count - 1)

--- a/sklearn_nature_inspired_algorithms/model_selection/_parameter_search.py
+++ b/sklearn_nature_inspired_algorithms/model_selection/_parameter_search.py
@@ -9,38 +9,36 @@ class ParameterSearch(Problem, ABC):
     def __init__(self, evaluate_candidates, param_grid):
         self.evaluate_candidates = evaluate_candidates
         self.param_grid = param_grid
+        # the algorithms revisit the same candidates, caching the scores
+        # avoids repeating the expensive cross-validation
         self.cache = {}
 
         Problem.__init__(self, dimension=len(param_grid), lower=0, upper=1)
 
-    def get_cache_key(self, params):
-        keys = self.param_grid.keys()
-        return tuple([params[key] for key in keys])
-
-    def get_cached_score(self, params):
-        cache_key = self.get_cache_key(params)
-
+    def get_cached_score(self, cache_key):
         if cache_key in self.cache:
             return self.cache[cache_key]
 
         return None
 
-    def set_cached_score(self, params, score):
-        cache_key = self.get_cache_key(params)
+    def set_cached_score(self, cache_key, score):
         self.cache[cache_key] = score
 
     def _evaluate(self, solution_vec):
-        params = self.param_grid.get_params_from_solution_vec(solution_vec)
+        # the cache is keyed by the indices of the selected parameter values
+        # since the values themselves may not be hashable (e.g. dicts)
+        cache_key = self.param_grid.get_value_indices_from_solution_vec(solution_vec)
 
-        score = self.get_cached_score(params)
+        score = self.get_cached_score(cache_key)
 
         if score is None:
+            params = self.param_grid.get_params_from_solution_vec(solution_vec)
             cv_results = self.evaluate_candidates([params])
             mean_test_score = cv_results['mean_test_score']
             # we need to invert the score since we are doing
             # a minimization task
             score = -mean_test_score[self.evaluation_count]
             self.evaluation_count += 1
-            self.set_cached_score(params, score)
+            self.set_cached_score(cache_key, score)
 
         return score

--- a/tests/model_selection/cross_validation_test_case.py
+++ b/tests/model_selection/cross_validation_test_case.py
@@ -39,6 +39,8 @@ class MockClassifierProxy(BaseEstimator):
 
 class CrossValidationTestCase(TestCase):
     def setUp(self):
+        # the mock is static, so it has to be reset to not leak call counts between tests
+        MockClassifierProxy.Mock.reset_mock()
         self.estimator = MockClassifierProxy()
 
     def test_cv_is_int(self):
@@ -60,7 +62,7 @@ class CrossValidationTestCase(TestCase):
 
         # set_params should be called each time new instance of estimator is created - for each individual in population
         method_calls = self.estimator.Mock.set_params.call_count
-        self.assertEqual(152, method_calls)
+        self.assertEqual(25 * 3 + 1, method_calls)
 
     @staticmethod
     def _get_nia_search(clf, cv):

--- a/tests/model_selection/nature_inspired_search_test_case.py
+++ b/tests/model_selection/nature_inspired_search_test_case.py
@@ -48,6 +48,23 @@ class NatureInspiredSearchTestCase(unittest.TestCase):
 
         self.assertFalse(has_different)
 
+    def test_dict_like_parameters(self):
+        # regression test for #24, dict values are not hashable,
+        # so they cannot be used in the score cache key directly
+        param_grid = {
+            'class_weight': [{False: 1, True: 2}, {False: 1, True: 1}],
+            'max_depth': range(2, 5),
+        }
+
+        X, y = make_classification(n_samples=100, n_features=20, flip_y=0.5, random_state=42)
+
+        clf = DecisionTreeClassifier(random_state=42)
+        search_clf = NatureInspiredSearchCV(clf, param_grid, algorithm='hba', max_n_gen=5, population_size=10, runs=2,
+                                            random_state=42)
+        search_clf.fit(X, y)
+
+        self.assertIn(search_clf.best_params_['class_weight'], param_grid['class_weight'])
+
     @staticmethod
     def get_classification_nature_inspired_search(search_clf_random_state=None):
         param_grid = {

--- a/tests/model_selection/param_grid_test_case.py
+++ b/tests/model_selection/param_grid_test_case.py
@@ -63,6 +63,29 @@ class ParamGridTestCase(unittest.TestCase):
             }
         )
 
+    def test_get_value_indices_from_solution_vec(self):
+        # the solution vectors are the same as in test_get_params_from_solution_vec,
+        # the indices point to the same values within the param grid
+        self.assertEqual(
+            self.param_grid.get_value_indices_from_solution_vec([0, 1, 0]),
+            (0, 9, 0)
+        )
+
+        self.assertEqual(
+            self.param_grid.get_value_indices_from_solution_vec([0.8, 0.89, 0.24]),
+            (0, 8, 0)
+        )
+
+        self.assertEqual(
+            self.param_grid.get_value_indices_from_solution_vec([0.8, 0.9, 0.25]),
+            (0, 9, 1)
+        )
+
+        self.assertEqual(
+            self.param_grid.get_value_indices_from_solution_vec([0.8, 0.5, 0.8]),
+            (0, 5, 3)
+        )
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary

Fixes #24 — `NatureInspiredSearchCV` raised `TypeError: unhashable type: 'dict'` when a parameter's candidate values were dicts (e.g. tuning `class_weight` on a `DecisionTreeClassifier`), an API-compatibility gap with `GridSearchCV`.

The root cause was the score cache in `ParameterSearch`, which used a tuple of the raw parameter *values* as the cache key. Since candidates are always selected by index from the param grid, the cache is now keyed by the tuple of selected value *indices* instead — hashable for any value type (dicts, lists, arrays, estimators).

## Changes

- `_param_grid.py`: factor the index computation out of `__get_param_value` and expose `get_value_indices_from_solution_vec()`.
- `_parameter_search.py`: key the score cache by value indices instead of parameter values. Side benefit: `get_params_from_solution_vec` is now only called on cache misses.
- Tests: unit tests for the new `ParamGrid` method, plus a regression test searching over dict-valued `class_weight` (the scenario from #24).
- Separate commit: reset the shared static mock in `CrossValidationTestCase.setUp` — it leaked `set_params` call counts between tests, and `test_cv_is_object`'s expected count of 152 silently included 76 calls from `test_cv_is_int`. The tests are now order-independent.

## Verification

- The exact reproduction script from #24 now runs cleanly and returns `best_params_`.
- `python -m unittest tests` (CI invocation): 9 tests, OK.
- `python -m unittest discover -s tests -p "*_test_case.py"`: 18 tests, OK (previously failed due to the mock leak).
- `flake8` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)