### PR TITLE
Support multi-metric scoring in NatureInspiredSearchCV

### DIFF
--- a/docs/introduction/nature-inspired-search-cv.rst
+++ b/docs/introduction/nature-inspired-search-cv.rst
@@ -31,6 +31,9 @@ Parameters
 The following parameters: **scoring**, **refit**, **verbose**, **pre_dispatch**, **error_score**, **return_train_score**, are inherited from sklearn's `BaseSearchCV <https://github.com/scikit-learn/scikit-learn/blob/1045d16ec13b1cab7878e7555538573d1884aad3/sklearn/model_selection/_search.py#L410>`_ and are the same as for the GridSearchCV.
 Refer to the GridSearchCV `documentation <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_ to find out what they do.
 
+When using multi-metric **scoring** (e.g. ``scoring={'AUC': 'roc_auc', 'F1': 'f1_macro'}``), the **refit** parameter must be set to the name of the metric to optimize (e.g. ``refit='F1'``).
+Unlike the exhaustive search in the GridSearchCV, the nature-inspired algorithm needs a single objective to optimize, so ``refit=False`` is not supported with multi-metric scoring.
+
 
 Glossary
 --------

--- a/sklearn_nature_inspired_algorithms/model_selection/_parameter_search.py
+++ b/sklearn_nature_inspired_algorithms/model_selection/_parameter_search.py
@@ -6,9 +6,12 @@ from niapy.problems import Problem
 class ParameterSearch(Problem, ABC):
     evaluation_count = 0
 
-    def __init__(self, evaluate_candidates, param_grid):
+    def __init__(self, evaluate_candidates, param_grid, score_key='mean_test_score'):
         self.evaluate_candidates = evaluate_candidates
         self.param_grid = param_grid
+        # the cv_results key with the optimized score, with multi-metric
+        # scoring there is one score column per metric instead of 'mean_test_score'
+        self.score_key = score_key
         # the algorithms revisit the same candidates, caching the scores
         # avoids repeating the expensive cross-validation
         self.cache = {}
@@ -34,7 +37,7 @@ class ParameterSearch(Problem, ABC):
         if score is None:
             params = self.param_grid.get_params_from_solution_vec(solution_vec)
             cv_results = self.evaluate_candidates([params])
-            mean_test_score = cv_results['mean_test_score']
+            mean_test_score = cv_results[self.score_key]
             # we need to invert the score since we are doing
             # a minimization task
             score = -mean_test_score[self.evaluation_count]

--- a/sklearn_nature_inspired_algorithms/model_selection/nature_inspired_search_cv.py
+++ b/sklearn_nature_inspired_algorithms/model_selection/nature_inspired_search_cv.py
@@ -22,7 +22,7 @@ class NatureInspiredSearchCV(BaseSearchCV):
         self.__param_grid = ParamGrid(self.param_grid)
         self.__algorithm = self.__get_algorithm(self.algorithm, self.population_size, self.random_state)
         self.__print_run_search_log()
-        problem = ParameterSearch(evaluate_candidates, self.__param_grid)
+        problem = ParameterSearch(evaluate_candidates, self.__param_grid, self.__get_score_key())
 
         self.optimization_logs_ = []
 
@@ -82,6 +82,20 @@ class NatureInspiredSearchCV(BaseSearchCV):
         self.optimization_logs_ = None
         self.cv_orig = None
         self.n_splits = None
+
+    def __get_score_key(self):
+        # with a single metric cv_results contain the 'mean_test_score' key,
+        # with multi-metric scoring there is one score column per metric instead
+        if self.scoring is None or isinstance(self.scoring, str) or callable(self.scoring):
+            return 'mean_test_score'
+
+        # unlike the exhaustive search in GridSearchCV, the nature-inspired algorithm
+        # needs a single objective to optimize, it is defined by the refit metric
+        if not isinstance(self.refit, str):
+            raise ValueError('For multi-metric scoring, refit must be set to the name of the metric '
+                             'to optimize, e.g. refit="accuracy".')
+
+        return f'mean_test_{self.refit}'
 
     def __print_run_search_log(self):
         candidates = self.__param_grid.get_number_of_candidates()

--- a/tests/model_selection/nature_inspired_search_test_case.py
+++ b/tests/model_selection/nature_inspired_search_test_case.py
@@ -65,6 +65,39 @@ class NatureInspiredSearchTestCase(unittest.TestCase):
 
         self.assertIn(search_clf.best_params_['class_weight'], param_grid['class_weight'])
 
+    def test_multi_metric_scoring(self):
+        # regression test for #23, with multi-metric scoring the cv_results
+        # do not contain 'mean_test_score', there is one score column per metric
+        # and the optimized metric is determined by refit
+        param_grid = {'max_depth': range(2, 5)}
+        scoring = {'AUC': 'roc_auc', 'F1': 'f1_macro'}
+
+        X, y = make_classification(n_samples=100, n_features=20, flip_y=0.5, random_state=42)
+
+        clf = DecisionTreeClassifier(random_state=42)
+        search_clf = NatureInspiredSearchCV(clf, param_grid, scoring=scoring, refit='F1', algorithm='hba',
+                                            max_n_gen=5, population_size=10, runs=2, random_state=42)
+        search_clf.fit(X, y)
+
+        self.assertIn('mean_test_AUC', search_clf.cv_results_)
+        self.assertIn('mean_test_F1', search_clf.cv_results_)
+        self.assertIn(search_clf.best_params_['max_depth'], param_grid['max_depth'])
+
+    def test_multi_metric_scoring_without_refit_metric(self):
+        # the nature-inspired algorithm needs a single objective to optimize,
+        # so multi-metric scoring requires refit to name the optimized metric
+        param_grid = {'max_depth': range(2, 5)}
+        scoring = {'AUC': 'roc_auc', 'F1': 'f1_macro'}
+
+        X, y = make_classification(n_samples=100, n_features=20, flip_y=0.5, random_state=42)
+
+        clf = DecisionTreeClassifier(random_state=42)
+        search_clf = NatureInspiredSearchCV(clf, param_grid, scoring=scoring, refit=False, algorithm='hba',
+                                            max_n_gen=5, population_size=10, runs=2, random_state=42)
+
+        with self.assertRaisesRegex(ValueError, 'refit must be set to the name of the metric'):
+            search_clf.fit(X, y)
+
     @staticmethod
     def get_classification_nature_inspired_search(search_clf_random_state=None):
         param_grid = {


### PR DESCRIPTION
## Summary

Fixes #23 — `NatureInspiredSearchCV` raised `KeyError: 'mean_test_score'` with multi-metric scoring (e.g. `scoring={'AUC': 'roc_auc', 'F1': 'f1_macro'}`), because in that case sklearn's `cv_results` contain one score column per metric (`mean_test_AUC`, `mean_test_F1`) and no `mean_test_score`.

The optimized metric is now determined by the `refit` parameter, mirroring how sklearn uses `refit` to select `best_index_` for multi-metric searches:

```python
NatureInspiredSearchCV(tree, param_grid, scoring={'AUC': 'roc_auc', 'F1': 'f1_macro'}, refit='F1').fit(X, y)
```

### Why `refit=False` is not supported with multi-metric scoring

The issue's reproduction uses `refit=False`. `GridSearchCV` supports that combination because an exhaustive search needs no objective — it just evaluates every candidate. A nature-inspired optimizer fundamentally needs a single scalar objective to drive the search, so there is nothing well-defined to optimize without a refit metric. That combination now raises a descriptive `ValueError` pointing the user to set `refit` to a metric name, instead of the cryptic `KeyError`.

## Changes

- `nature_inspired_search_cv.py`: new private `__get_score_key()` — returns `'mean_test_score'` for single-metric scoring, `f'mean_test_{refit}'` for multi-metric, and raises a clear `ValueError` for multi-metric without a string `refit`.
- `_parameter_search.py`: `ParameterSearch` accepts the `cv_results` score key instead of hardcoding `'mean_test_score'`.
- Tests: multi-metric search with `refit='F1'` (checks `cv_results_` columns and `best_params_`), and the `refit=False` error path.
- Docs: note in the `NatureInspiredSearchCV` parameter docs about multi-metric scoring requiring a refit metric.

## Verification

- The reproduction from #23 works with `refit='F1'` and returns `best_params_`/`best_score_`; with the original `refit=False` it raises the descriptive `ValueError`.
- `python -m unittest tests`: 11 tests, OK. `flake8` clean.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
