### PR TITLE
Document n_jobs limitation in embedded Python environments

### DIFF
--- a/docs/introduction/nature-inspired-search-cv.rst
+++ b/docs/introduction/nature-inspired-search-cv.rst
@@ -28,6 +28,18 @@ Parameters
 - **verbose**: *int, default=0.* The level of the logging, possible values: 0, 1, 2.
 - **n_jobs**: *int, default=None.* Number of jobs to run in parallel. None means 1 unless in a joblib.parallel_backend context. -1 means using all processors. This affects the number of jobs when evaluating a model for one _individual_ (for one individual there might be more model evaluations because of cross-validation) not for the whole population - current implementations of nature-inspired algorithms do not support multiprocessing. You will benefit from multiprocessing only if you use cross-validation.
 
+.. note::
+    The parallelization is process-based, sklearn handles it via `joblib <https://joblib.readthedocs.io/>`_ and its default ``loky`` backend.
+    In environments where spawning processes is not possible (e.g. when Python is embedded in another application, such as a .NET host via pythonnet), it may fail with errors like ``OSError: [Errno 22] Invalid argument``.
+    In such environments either leave ``n_jobs=None``, or use joblib's threading backend, which avoids spawning processes:
+
+    .. code-block:: python
+
+        from joblib import parallel_backend
+
+        with parallel_backend('threading'):
+            search.fit(X, y)
+
 The following parameters: **scoring**, **refit**, **verbose**, **pre_dispatch**, **error_score**, **return_train_score**, are inherited from sklearn's `BaseSearchCV <https://github.com/scikit-learn/scikit-learn/blob/1045d16ec13b1cab7878e7555538573d1884aad3/sklearn/model_selection/_search.py#L410>`_ and are the same as for the GridSearchCV.
 Refer to the GridSearchCV `documentation <https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.GridSearchCV.html>`_ to find out what they do.
 


### PR DESCRIPTION
## Summary

Relates to #19 — `OSError: [Errno 22] Invalid argument` with `n_jobs` set.

The investigation concluded this is not a defect in this library: `n_jobs` is passed straight to sklearn's `BaseSearchCV`, which parallelizes cross-validation with joblib's process-based `loky` backend. The error comes from loky's resource tracker failing while spawning worker processes inside an *embedded* Python interpreter (the reporter runs Python inside a .NET host via pythonnet — and confirmed the same code works in a plain Python environment).

This PR documents the limitation and the workaround in the `n_jobs` parameter docs: use joblib's threading backend (avoids process spawning entirely) or leave `n_jobs=None`.

## Verification

- `n_jobs=-1` and `n_jobs=2` verified working with current versions (joblib 1.5.3, sklearn 1.8.0) in a standard environment.
- The documented `parallel_backend('threading')` workaround verified working with `NatureInspiredSearchCV`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)