### PR TITLE
Update supported Python versions and dependency floors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,12 +4,17 @@
 # Required
 version: 2
 
+# Set the version of Python and OS used to build the docs
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: docs/conf.py
 
-# Optionally set the version of Python and requirements required to build your docs
+# Requirements required to build the docs
 python:
-  version: "3.12"
   install:
     - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
+sphinx
 sphinx-rtd-theme

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,20 +8,20 @@ version = "0.13.0"
 description = "Search using nature inspired algorithms over specified parameter values for an sklearn estimator."
 license = "MIT"
 readme = "README.md"
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 authors = [
     { name = "Timotej Zatko", email = "timi.zatko@gmail.com" },
 ]
 keywords = ["sklearn", "scikit-learn", "nature-inspired-algorithms", "hyper-parameter-tuning"]
 
 dependencies = [
-    "scikit-learn >= 1.0.2",
-    "numpy >= 1.22",
-    "matplotlib >= 3.5",
-    "seaborn >= 0.11",
-    "pandas >= 1.4",
-    "niapy >= 2.0",
-    "scipy >= 1.7.3",
+    "scikit-learn >= 1.4.2",
+    "numpy >= 1.26",
+    "matplotlib >= 3.9",
+    "seaborn >= 0.13",
+    "pandas >= 2.2.2",
+    "niapy >= 2.5.1",
+    "scipy >= 1.13",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary

Modernizes the supported Python range and dependency metadata:

- **Python**: drop 3.9 (EOL since October 2025), raise `requires-python` to `>= 3.10`, and add **Python 3.14** to the CI matrix (now 3.10–3.14).
- **Dependency floors**: raised to the first numpy 2.x-compatible releases (`scikit-learn >= 1.4.2`, `numpy >= 1.26`, `pandas >= 2.2.2`, `scipy >= 1.13`, `matplotlib >= 3.9`, `seaborn >= 0.13`, `niapy >= 2.5.1`). The old floors (numpy 1.22-era) permitted dependency resolutions that are mutually incompatible with modern numpy.
- **ReadTheDocs**: migrate `.readthedocs.yml` from the deprecated `python.version` key to the required `build.os` + `build.tools` format, and declare `sphinx` explicitly in `docs/requirements.txt` (no longer installed implicitly with the new build images).

## Verification

Tests pass at both ends of the supported dependency range (fresh venvs, Python 3.11):

- **Latest**: scikit-learn 1.9.0, numpy 2.4.6, pandas 3.0.3, scipy 1.17.1, matplotlib 3.10.9, seaborn 0.13.2, niapy 2.7.0 — all tests OK (including the private `sklearn.model_selection._search` import, which still works on 1.9).
- **Floors**: scikit-learn 1.4.2, numpy 1.26.4, pandas 2.2.2, scipy 1.13.0, matplotlib 3.9.0, seaborn 0.13.0, niapy 2.5.1 — all tests OK.
- CI matrix (3.10–3.14) runs on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)