### PR TITLE
Fix broken CI and Python version badges in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Nature-Inspired Algorithms for scikit-learn
 
-[![CI](https://github.com/timzatko/Sklearn-Nature-Inspired-Algorithms/workflows/CI/badge.svg?branch=master)](https://github.com/timzatko/Sklearn-Nature-Inspired-Algorithms/actions?query=workflow:CI+branch:master)
-![PyPI - Python Version](https://img.shields.io/pypi/pyversions/sklearn-nature-inspired-algorithms)
+[![CI](https://github.com/timzatko/Sklearn-Nature-Inspired-Algorithms/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/timzatko/Sklearn-Nature-Inspired-Algorithms/actions/workflows/ci.yml?query=branch%3Amaster)
+![Python Version](https://img.shields.io/python/required-version-toml?tomlFilePath=https%3A%2F%2Fraw.githubusercontent.com%2Ftimzatko%2FSklearn-Nature-Inspired-Algorithms%2Fmaster%2Fpyproject.toml)
 [![PyPI version](https://badge.fury.io/py/sklearn-nature-inspired-algorithms.svg)](https://pypi.org/project/sklearn-nature-inspired-algorithms/)
 [![PyPI downloads](https://img.shields.io/pypi/dm/sklearn-nature-inspired-algorithms)](https://pypi.org/project/sklearn-nature-inspired-algorithms/)
 [![Fedora package](https://img.shields.io/fedora/v/python3-sklearn-nature-inspired-algorithms?color=blue&label=Fedora%20Linux&logo=fedora)](https://src.fedoraproject.org/rpms/python-sklearn-nature-inspired-algorithms)


### PR DESCRIPTION
## Summary

Two of the README badges no longer rendered correctly:

- **CI badge** showed "CI - no status" — it used GitHub's legacy `workflows/CI/badge.svg` URL format, which no longer resolves. Replaced with the current `actions/workflows/ci.yml/badge.svg` format and pointed the link at the workflow run history.
- **Python version badge** showed "python: missing" — the `pypi/pyversions` badge reads trove classifiers from the published PyPI release, and the package publishes none. Replaced with shields.io's `python/required-version-toml` badge, which reads `requires-python` directly from `pyproject.toml` on master and renders "python: >= 3.10".

The remaining badges (PyPI version, downloads, Fedora) render fine and are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)