### PR TITLE
Raise test coverage from 74% to 99%

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,10 @@
 import unittest
 
+from .helpers import PlotsTestCase
 from .model_selection import NatureInspiredSearchTestCase, \
     ParamGridTestCase, \
-    CrossValidationTestCase
+    CrossValidationTestCase, \
+    StagnationStoppingTaskTestCase
 
 
 def get_suite():
@@ -11,6 +13,8 @@ def get_suite():
     suite.addTest(NatureInspiredSearchTestCase())
     suite.addTest(ParamGridTestCase())
     suite.addTest(CrossValidationTestCase())
+    suite.addTest(StagnationStoppingTaskTestCase())
+    suite.addTest(PlotsTestCase())
 
     return suite
 

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+from .plots_test_case import PlotsTestCase

--- a/tests/helpers/plots_test_case.py
+++ b/tests/helpers/plots_test_case.py
@@ -1,0 +1,58 @@
+import unittest
+
+from types import SimpleNamespace
+
+import matplotlib
+import matplotlib.pyplot as plt
+
+from matplotlib.axes import Axes
+
+from sklearn_nature_inspired_algorithms.helpers import score_by_generation_lineplot, score_by_generation_violinplot
+
+matplotlib.use('Agg')
+
+
+class PlotsTestCase(unittest.TestCase):
+    def setUp(self):
+        # two runs with three generations each and two evaluations per generation,
+        # the helpers only read the optimization_logs_ of the search
+        self.nia_search = SimpleNamespace(optimization_logs_=[
+            [(1, 0.50), (1, 0.55), (2, 0.60), (2, 0.65), (3, 0.70), (3, 0.75)],
+            [(1, 0.40), (1, 0.45), (2, 0.55), (2, 0.60), (3, 0.65), (3, 0.70)],
+        ])
+
+    def tearDown(self):
+        plt.close('all')
+
+    def test_lineplot_returns_axes_for_all_metrics(self):
+        for metric in ['min', 'max', 'median', 'mean']:
+            ax = score_by_generation_lineplot(self.nia_search, metric=metric)
+
+            self.assertIsInstance(ax, Axes)
+
+            plt.close('all')
+
+    def test_lineplot_with_custom_ax_and_ylim(self):
+        _, ax = plt.subplots()
+
+        self.assertIsInstance(score_by_generation_lineplot(self.nia_search, ax=ax, ylim=(0, 1)), Axes)
+
+    def test_lineplot_with_invalid_metric(self):
+        with self.assertRaisesRegex(ValueError, 'is not in the allowed metrics'):
+            score_by_generation_lineplot(self.nia_search, metric='sum')
+
+    def test_violinplot_returns_axes(self):
+        self.assertIsInstance(score_by_generation_violinplot(self.nia_search, run=1), Axes)
+
+    def test_violinplot_with_custom_ax_and_ylim(self):
+        _, ax = plt.subplots()
+
+        self.assertIsInstance(score_by_generation_violinplot(self.nia_search, run=0, ax=ax, ylim=(0, 1)), Axes)
+
+    def test_violinplot_with_invalid_run(self):
+        with self.assertRaisesRegex(ValueError, 'does not exist'):
+            score_by_generation_violinplot(self.nia_search, run=2)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/model_selection/__init__.py
+++ b/tests/model_selection/__init__.py
@@ -1,3 +1,4 @@
 from .param_grid_test_case import ParamGridTestCase
 from .nature_inspired_search_test_case import NatureInspiredSearchTestCase
 from .cross_validation_test_case import CrossValidationTestCase
+from .stagnation_stopping_task_test_case import StagnationStoppingTaskTestCase

--- a/tests/model_selection/nature_inspired_search_test_case.py
+++ b/tests/model_selection/nature_inspired_search_test_case.py
@@ -1,4 +1,9 @@
+import io
 import unittest
+
+from contextlib import redirect_stdout
+
+from niapy.algorithms.basic import GeneticAlgorithm
 
 from sklearn_nature_inspired_algorithms.model_selection import NatureInspiredSearchCV
 
@@ -97,6 +102,46 @@ class NatureInspiredSearchTestCase(unittest.TestCase):
 
         with self.assertRaisesRegex(ValueError, 'refit must be set to the name of the metric'):
             search_clf.fit(X, y)
+
+    def test_all_supported_algorithms(self):
+        for algorithm in ['fa', 'ba', 'hba', 'hsaba', 'gwo']:
+            search_clf = self.get_tiny_nature_inspired_search(algorithm)
+
+            self.assertIn(search_clf.best_params_['max_depth'], range(2, 5))
+
+    def test_not_supported_algorithm(self):
+        with self.assertRaisesRegex(ValueError, 'is not in supported algorithms'):
+            self.get_tiny_nature_inspired_search('invalid-algorithm')
+
+    def test_custom_algorithm(self):
+        algorithm = GeneticAlgorithm()
+        algorithm.set_parameters(NP=10, Ts=4, Mr=0.25)
+
+        search_clf = self.get_tiny_nature_inspired_search(algorithm)
+
+        self.assertIn(search_clf.best_params_['max_depth'], range(2, 5))
+
+    def test_verbose_logging(self):
+        out = io.StringIO()
+
+        with redirect_stdout(out):
+            self.get_tiny_nature_inspired_search('hba', verbose=2)
+
+        self.assertIn('Iteration', out.getvalue())
+        self.assertIn('Run 1/1 finished', out.getvalue())
+
+    @staticmethod
+    def get_tiny_nature_inspired_search(algorithm, verbose=0):
+        param_grid = {'max_depth': range(2, 5)}
+
+        X, y = make_classification(n_samples=50, n_features=10, flip_y=0.5, random_state=42)
+
+        clf = DecisionTreeClassifier(random_state=42)
+        search_clf = NatureInspiredSearchCV(clf, param_grid, algorithm=algorithm, max_n_gen=3, max_stagnating_gen=2,
+                                            population_size=5, runs=1, random_state=42, verbose=verbose)
+        search_clf.fit(X, y)
+
+        return search_clf
 
     @staticmethod
     def get_classification_nature_inspired_search(search_clf_random_state=None):

--- a/tests/model_selection/param_grid_test_case.py
+++ b/tests/model_selection/param_grid_test_case.py
@@ -13,6 +13,14 @@ class ParamGridTestCase(unittest.TestCase):
 
         self.param_grid = ParamGrid(param_grid_value)
 
+    def test_param_grid_cannot_be_none(self):
+        with self.assertRaisesRegex(ValueError, 'param_grid cannot be None'):
+            ParamGrid(None)
+
+    def test_keys_and_values(self):
+        self.assertEqual(self.param_grid.keys(), ('param_a', 'param_b', 'param_c'))
+        self.assertEqual(list(self.param_grid.values()), [[100], range(1, 11), [0.1, 0.2, 0.3, 0.4]])
+
     def test_param_grid_index_and_key_mappings(self):
         self.assertEqual(self.param_grid.index_to_key_map, {
             0: 'param_a',

--- a/tests/model_selection/stagnation_stopping_task_test_case.py
+++ b/tests/model_selection/stagnation_stopping_task_test_case.py
@@ -1,0 +1,41 @@
+import unittest
+
+from niapy.problems import Problem
+
+from sklearn_nature_inspired_algorithms.model_selection._stagnation_stopping_task import StagnationStoppingTask
+
+
+class ConstantProblem(Problem):
+    def __init__(self):
+        super().__init__(dimension=2, lower=0, upper=1)
+
+    def _evaluate(self, x):
+        return 0.0
+
+
+class StagnationStoppingTaskTestCase(unittest.TestCase):
+    def test_max_stagnating_gen_must_be_int_or_none(self):
+        with self.assertRaisesRegex(ValueError, 'should be int or None'):
+            StagnationStoppingTask(max_iters=10, max_stagnating_gen='5', problem=ConstantProblem())
+
+    def test_max_stagnating_gen_must_be_at_least_one(self):
+        with self.assertRaisesRegex(ValueError, 'greater or equal to 1'):
+            StagnationStoppingTask(max_iters=10, max_stagnating_gen=0, problem=ConstantProblem())
+
+    def test_stops_when_score_stagnates(self):
+        task = StagnationStoppingTask(max_iters=10, max_stagnating_gen=1, problem=ConstantProblem())
+
+        task.x_f = 1.0
+        task.eval_stagnation()  # the first generation only sets the baseline score
+
+        self.assertFalse(task.is_stagnating)
+        self.assertFalse(task.stopping_condition())
+
+        task.eval_stagnation()  # the score did not improve, the stagnation limit is reached
+
+        self.assertTrue(task.is_stagnating)
+        self.assertTrue(task.stopping_condition())
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes the main coverage gaps in the test suite, raising overall coverage from 74% to 99% (26 tests, all passing, flake8 clean).

- **Plot helpers (0% → 100%):** new `tests/helpers/plots_test_case.py` with smoke tests for `score_by_generation_lineplot` (all four metrics, custom ax/ylim, invalid-metric error) and `score_by_generation_violinplot` (valid run, custom ax/ylim, invalid-run error), using a stub search object and the Agg backend.
- **`NatureInspiredSearchCV` (84% → 99%):** tiny fits for each supported algorithm string (`fa`, `ba`, `hba`, `hsaba`, `gwo`), the invalid-algorithm `ValueError`, the custom NiaPy algorithm passthrough from the README, and `verbose=2` logging asserted via captured stdout.
- **`StagnationStoppingTask` (86% → 100%):** new test case for both `max_stagnating_gen` validation errors and for the stagnation limit flipping the stopping condition.
- **`ParamGrid` (92% → 100%):** tests for the `None` grid error and the `keys()`/`values()` accessors.

The only remaining uncovered line is the re-raise of an exception captured by NiaPy during an optimization run (`nature_inspired_search_cv.py:50`), which would require injecting a failure into NiaPy internals to reach.

## Test plan

- `coverage run --source=./sklearn_nature_inspired_algorithms -m unittest tests` — Ran 26 tests, OK
- `coverage report` — TOTAL 99%
- `flake8 ./tests ./sklearn_nature_inspired_algorithms` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)