### PR TITLE
Update workflow actions and publish via PyPI trusted publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,10 @@ name: CI
 on:
   push:
     branches:
-      - '*'
+      - master
     tags:
       - v*
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install Dependencies
@@ -33,7 +33,7 @@ jobs:
     - name: Build
       run: |
         python -m build
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       if: ${{ matrix.python-version == '3.12' }}
       with:
         name: dist
@@ -44,12 +44,12 @@ jobs:
     runs-on: ubuntu-latest
     needs: build
     steps:
-    - uses: actions/download-artifact@v4
+    - uses: actions/download-artifact@v8
       with:
         name: dist
         path: dist
     - name: Create Draft Release
-      uses: softprops/action-gh-release@v2
+      uses: softprops/action-gh-release@v3
       with:
         draft: true
         files: dist/*

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,23 +8,15 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.12"
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install twine
       - name: Download release assets
-        run: |
-          mkdir -p dist
-          curl -s "https://api.github.com/repos/$GITHUB_REPOSITORY/releases/tags/$(echo $GITHUB_REF | grep -oE "[^/]+$")" |
-          grep "browser_download_url" | cut -d : -f 2,3 | tr -d '"' | wget -P dist -qi -
-      - name: Publish to pypi.org
         env:
-          PYPI_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
-          PYPI_USERNAME: ${{ secrets.PYPI_USERNAME }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          twine upload -u "$PYPI_USERNAME" -p "$PYPI_PASSWORD" dist/*
+          gh release download "${{ github.event.release.tag_name }}" --repo "$GITHUB_REPOSITORY" --dir dist
+      - name: Publish to pypi.org
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
-    environment: pypi
+    environment: Production
     permissions:
       contents: read
       id-token: write


### PR DESCRIPTION
## Summary

### CI triggers fixed

CI never ran on PR branches: the `'*'` branch filter does not match branch names containing a slash (e.g. `fix/readme-badges`), and there was no `pull_request` trigger — recent PRs (#34, #35) only got CI after merging to master. CI now triggers on pull requests and on pushes to master and `v*` tags, which also avoids duplicate runs for PR branches.

### Action version bumps (both workflows)

| Action | Before | After |
|---|---|---|
| `actions/checkout` | v4 | v6 |
| `actions/setup-python` | v5 | v6 |
| `actions/upload-artifact` | v4 | v7 |
| `actions/download-artifact` | v4 | v8 |
| `softprops/action-gh-release` | v2 | v3 |

Per the release notes, the breaking changes across these majors are the Node 24 runtime (transparent on GitHub-hosted runners), the artifact actions' move to ESM, and download-artifact now failing on digest mismatch instead of warning. None affect our usage; upload-artifact v7 and download-artifact v8 are the matching pair.

### Publish workflow modernization

- Replaced the `twine upload -u $PYPI_USERNAME -p $PYPI_PASSWORD` step with `pypa/gh-action-pypi-publish` using OIDC [trusted publishing](https://docs.pypi.org/trusted-publishers/) — PyPI no longer supports username/password auth, and this removes the need for long-lived secrets entirely.
- Replaced the `curl | grep | cut | tr | wget` release-asset download with `gh release download`.
- Dropped the now-unneeded checkout, Python setup, and twine install steps.

## ⚠️ One-time setup required before the next release

On [PyPI publishing settings](https://pypi.org/manage/project/sklearn-nature-inspired-algorithms/settings/publishing/), add a trusted publisher:

- **Owner:** `timzatko`
- **Repository:** `Sklearn-Nature-Inspired-Algorithms`
- **Workflow:** `publish.yml`
- **Environment:** `Production`

After the first successful publish, the `PYPI_USERNAME` / `PYPI_PASSWORD` repo secrets can be deleted. Optionally add protection rules to it under repo Settings → Environments.

## Test plan

- Both workflow files pass YAML lint.
- The new `pull_request` trigger runs CI on this PR itself, exercising the bumped checkout/setup-python/upload-artifact versions.
- The release/publish path can only be fully verified on the next tagged release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)