### PR TITLE
Bump version to v0.14.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "sklearn-nature-inspired-algorithms"
-version = "0.13.0"
+version = "0.14.0"
 description = "Search using nature inspired algorithms over specified parameter values for an sklearn estimator."
 license = "MIT"
 readme = "README.md"

--- a/version.sh
+++ b/version.sh
@@ -1,9 +1,25 @@
-#!/bin/bash
+#!/bin/sh
+
+set -e
 
 version=$1
+PYTHON=${PYTHON:-}
+
+if [ -z "$PYTHON" ]; then
+  if command -v python3 >/dev/null 2>&1; then
+    PYTHON=python3
+  else
+    PYTHON=python
+  fi
+fi
+
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "Python interpreter not found. Install python3 or set PYTHON=/path/to/python."
+  exit 1
+fi
 
 # check semver regex
-if [[ $(python ./scripts/is_semver.py $version) == "true" ]]; then
+if "$PYTHON" ./scripts/is_semver.py "$version" >/dev/null; then
   echo "$version"
   sed -i.bak "s/^version = .*/version = \"${version#v}\"/" pyproject.toml && rm -f pyproject.toml.bak
   git commit -am "Bump version to $version"
@@ -12,4 +28,3 @@ else
   echo "Version \"$version\" does not satisfy semantic versioning requirements!"
   exit 2
 fi
-


### PR DESCRIPTION
## Summary
- bump package version to 0.14.0
- make version.sh portable across POSIX shells and configurable Python interpreters

## Validation
- ./version.sh bad-version
- ./version.sh v0.14.0